### PR TITLE
Improve cot() function, to ensure x is not exactly a multiple of pi/2

### DIFF
--- a/src/sphstat/utils.py
+++ b/src/sphstat/utils.py
@@ -324,7 +324,10 @@ def cot(x):
     :return: Cotangent of the input
     :rtype: float
     """
-    return 1/np.tan(x)
+
+    # By subtracting the smallest positive representable number (eps) from x,
+    # the expression ensures that x is not exactly a multiple of pi/2 and thus the tangent of x is defined.
+    return 1/np.tan(x - np.finfo(float).eps)
 
 
 def poltoll(th: float, ph: float) -> tuple:


### PR DESCRIPTION
Hi! This is a quick fix for cot() function, to ensure that it doesn't return Inf or -Inf. This is because the tangent of x is undefined when x is a multiple of pi/2, which would result in a division by zero error if not handled properly. By subtracting the smallest positive representable number (eps) from x, the expression ensures that x is not exactly a multiple of pi/2 and thus the tangent of x is defined. 