### PR TITLE
Fix deprecation warning from pkg_resources in sphstat.twosample

### DIFF
--- a/src/sphstat/twosample.py
+++ b/src/sphstat/twosample.py
@@ -52,11 +52,21 @@ from scipy.stats import chi2
 from scipy.stats import f as fish
 import pandas as pd
 from math import sqrt
+import importlib.resources as resources
 
 from .descriptives import resultants, mediandir, rotatesample
 from .singlesample import meanifsymmetric, fisherparams
 from .utils import cart2sph, sph2cart, poolsamples, carttopolar, maptofundamental
-import pkg_resources as pkg
+
+
+def _read_excel_resource(resource_name: str) -> pd.DataFrame:
+    """Load packaged Excel data."""
+    if hasattr(resources, "files"):
+        data_path = resources.files("sphstat").joinpath("data", resource_name)
+        with resources.as_file(data_path) as resolved_path:
+            return pd.read_excel(resolved_path)
+    with resources.path("sphstat", f"data/{resource_name}") as resolved_path:
+        return pd.read_excel(resolved_path)
 
 
 def iscommonmedian(samplecartlist: list, similarflag: bool = True, alpha: float = 0.05) -> dict:
@@ -472,8 +482,7 @@ def a20(N=12, alpha: float = 0.05, Rbar: float = 0.7):
     except AssertionError:
         raise AssertionError('Test level, alpha, should be either 0.1, 0.05, 0.025, or 0.01.')
 
-    filepath = pkg.resource_filename(__name__, 'data/A20.xlsx')
-    df = pd.read_excel(filepath)
+    df = _read_excel_resource("A20.xlsx")
     Narr = list(set(df['N'].tolist()))
     interpNflag = False
     interpRflag = False
@@ -603,8 +612,7 @@ def a21(gamma=2, N=20, alpha=0.05, Rbar=0.1):
         z0i = z0gamma['z0'].values[0]
         return z0i
 
-    filepath = pkg.resource_filename(__name__, 'data/A21.xlsx')
-    df = pd.read_excel(filepath)
+    df = _read_excel_resource("A21.xlsx")
 
     if Rbar not in Rlist:
         interpRflag = True
@@ -691,8 +699,7 @@ def a23(nu=2, r=2):
             nu2 = nuo[nuind + 1]
             betanu = (nu - nu1) / (nu2 - nu1)
 
-    filepath = pkg.resource_filename(__name__, 'data/A23.xlsx')
-    df = pd.read_excel(filepath)
+    df = _read_excel_resource("A23.xlsx")
 
     def selectval_a23(dfi, nui, ri):
         dfnu = dfi[dfi['nu'] == nui]


### PR DESCRIPTION
Importing `sphstat` currently prints the following warning:
```
/home/vlad/.cache/pypoetry/virtualenvs/web-app-Dk6Rue85-py3.10/lib/python3.10/site-packages/sphstat/twosample.py:59: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources as pkg
  ```
  This eliminates the warning, by using `importlib.resources` instead of `pkg_resources`.
  
  tested by calling:
  ```
  import sys
sys.path.insert(0, 'src')
from sphstat.twosample import a20, a21, a23
print('a20:', a20(N=12, alpha=0.05, Rbar=0.7))
print('a21:', a21(gamma=2, N=20, alpha=0.05, Rbar=0.1))
print('a23:', a23(nu=2, r=2))
```

```
a20: 0.793
a21: 0.355
a23: 39.0
```